### PR TITLE
Refactor dao physical foreign keys to logical

### DIFF
--- a/cmd/database.go
+++ b/cmd/database.go
@@ -21,6 +21,7 @@ var migrateDatabaseCmd = &cobra.Command{
 		database.InitDatabase()
 		db := database.GetDBInstance(cmd.Context())
 		lo.Must0(db.AutoMigrate(model.Models...))
+		lo.Must0(database.DropAllForeignKeys(cmd.Context()))
 	},
 }
 

--- a/internal/resource/database/migration.go
+++ b/internal/resource/database/migration.go
@@ -1,0 +1,116 @@
+package database
+
+import (
+    "context"
+    "fmt"
+    "strings"
+)
+
+// DropAllForeignKeys 删除当前 schema 下所有表的物理外键约束，实现逻辑外键
+//
+//	param ctx context.Context
+//	return error
+//	author centonhuang
+//	update 2025-01-19 20:20:00
+func DropAllForeignKeys(ctx context.Context) error {
+    gdb := db.WithContext(ctx)
+
+    // 查询当前 schema 下的所有外键约束名称与表名
+    type row struct {
+        ConstraintName string
+        TableName      string
+        SchemaName     string
+    }
+
+    rows, err := gdb.Raw(`
+        SELECT con.conname AS constraint_name,
+               rel.relname AS table_name,
+               nsp.nspname AS schema_name
+        FROM pg_constraint con
+        JOIN pg_class rel ON rel.oid = con.conrelid
+        JOIN pg_namespace nsp ON nsp.oid = con.connamespace
+        WHERE con.contype = 'f' AND nsp.nspname = current_schema();
+    `).Rows()
+    if err != nil {
+        return err
+    }
+    defer rows.Close()
+
+    drops := make([]string, 0, 16)
+    for rows.Next() {
+        var r row
+        if err := rows.Scan(&r.ConstraintName, &r.TableName, &r.SchemaName); err != nil {
+            return err
+        }
+        // 生成 drop 语句，使用双引号保证大小写与特殊字符
+        drops = append(drops, fmt.Sprintf(`ALTER TABLE "%s"."%s" DROP CONSTRAINT IF EXISTS "%s";`, r.SchemaName, r.TableName, r.ConstraintName))
+    }
+
+    if len(drops) == 0 {
+        return nil
+    }
+
+    // 合并为一条批量语句以减少往返
+    batch := strings.Join(drops, "\n")
+    return gdb.Exec(batch).Error
+}
+
+package database
+
+import (
+    "context"
+    "fmt"
+    "strings"
+
+    "github.com/samber/lo"
+)
+
+// DropAllForeignKeys 删除当前 schema 下所有表的物理外键约束，实现逻辑外键
+//
+//	param ctx context.Context
+//	return error
+//	author centonhuang
+//	update 2025-01-19 20:20:00
+func DropAllForeignKeys(ctx context.Context) error {
+    gdb := db.WithContext(ctx)
+
+    // 查询当前 schema 下的所有外键约束名称与表名
+    type row struct {
+        ConstraintName string
+        TableName      string
+        SchemaName     string
+    }
+
+    rows, err := gdb.Raw(`
+        SELECT con.conname AS constraint_name,
+               rel.relname AS table_name,
+               nsp.nspname AS schema_name
+        FROM pg_constraint con
+        JOIN pg_class rel ON rel.oid = con.conrelid
+        JOIN pg_namespace nsp ON nsp.oid = con.connamespace
+        WHERE con.contype = 'f' AND nsp.nspname = current_schema();
+    `).Rows()
+    if err != nil {
+        return err
+    }
+    defer rows.Close()
+
+    drops := make([]string, 0, 16)
+    for rows.Next() {
+        var r row
+        if err := rows.Scan(&r.ConstraintName, &r.TableName, &r.SchemaName); err != nil {
+            return err
+        }
+        // 生成 drop 语句，使用双引号保证大小写与特殊字符
+        drops = append(drops, fmt.Sprintf(`ALTER TABLE "%s"."%s" DROP CONSTRAINT IF EXISTS "%s";`, r.SchemaName, r.TableName, r.ConstraintName))
+    }
+
+    if len(drops) == 0 {
+        return nil
+    }
+
+    // 合并为一条批量语句以减少往返
+    batch := strings.Join(drops, "\n")
+    return gdb.Exec(batch).Error
+}
+

--- a/internal/resource/database/postgresql.go
+++ b/internal/resource/database/postgresql.go
@@ -58,15 +58,16 @@ func InitDatabase() {
 
 	// 	dsn := fmt.Sprintf("%s:%s@tcp(%s:%s)/%s?charset=utf8mb4&parseTime=True&loc=Local",
 	// 		config.MysqlUser, config.MysqlPassword, config.MysqlHost, config.MysqlPort, config.MysqlDatabase)
-	// 	dialector = mysql.New(mysql.Config{
-	// 		DSN:               dsn,
-	// 		DefaultStringSize: 256,
-	// 	})
-	// 	dbHost, dbPort, dbName = config.MysqlHost, config.MysqlPort, config.MysqlDatabase
+	// 	 dialector = mysql.New(mysql.Config{
+	// 		 DSN:               dsn,
+	// 		 DefaultStringSize: 256,
+	// 	 })
+	// 	 dbHost, dbPort, dbName = config.MysqlHost, config.MysqlPort, config.MysqlDatabase
 
 	db = lo.Must(gorm.Open(dialector, &gorm.Config{
 		DryRun:         false, // 只生成SQL不运行
 		TranslateError: true,
+		DisableForeignKeyConstraintWhenMigrating: true,
 		Logger: &GormLoggerAdapter{
 			LogLevel: gormlogger.Info, // Info级别
 		},


### PR DESCRIPTION
Refactor DAO layer to use logical foreign keys by disabling GORM's physical foreign key creation and adding a migration step to drop existing ones.

---
<a href="https://cursor.com/background-agent?bcId=bc-a7fbf9c1-dcc7-449e-91c1-79ad9a3ab54a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a7fbf9c1-dcc7-449e-91c1-79ad9a3ab54a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

