### PR TITLE
Refactor DAO foreign keys to logical

### DIFF
--- a/cmd/database.go
+++ b/cmd/database.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"github.com/hcd233/aris-blog-api/internal/resource/database"
 	"github.com/hcd233/aris-blog-api/internal/resource/database/model"
 	"github.com/samber/lo"
@@ -24,7 +25,45 @@ var migrateDatabaseCmd = &cobra.Command{
 	},
 }
 
+var dropFKCmd = &cobra.Command{
+    Use:   "drop-fk",
+    Short: "移除所有物理外键约束（Postgres）",
+    Long:  "扫描当前数据库的所有非系统schema，删除所有外键约束，以便完全使用逻辑外键。",
+    Run: func(cmd *cobra.Command, _ []string) {
+        database.InitDatabase()
+        db := database.GetDBInstance(cmd.Context())
+
+        type fkRow struct {
+            TableSchema string
+            TableName   string
+            Constraint  string
+        }
+
+        var rows []fkRow
+        // 查询所有外键约束
+        raw := db.Raw(`
+            SELECT tc.table_schema AS table_schema,
+                   tc.table_name   AS table_name,
+                   tc.constraint_name AS constraint
+            FROM information_schema.table_constraints tc
+            WHERE tc.constraint_type = 'FOREIGN KEY'
+              AND tc.table_schema NOT IN ('pg_catalog','information_schema')
+        `)
+        if err := raw.Scan(&rows).Error; err != nil {
+            lo.Must0(err)
+        }
+
+        for _, r := range rows {
+            stmt := fmt.Sprintf("ALTER TABLE \"%s\".\"%s\" DROP CONSTRAINT IF EXISTS \"%s\";", r.TableSchema, r.TableName, r.Constraint)
+            if err := db.Exec(stmt).Error; err != nil {
+                lo.Must0(err)
+            }
+        }
+    },
+}
+
 func init() {
 	databaseCmd.AddCommand(migrateDatabaseCmd)
+	databaseCmd.AddCommand(dropFKCmd)
 	rootCmd.AddCommand(databaseCmd)
 }

--- a/internal/resource/database/model/user_like.go
+++ b/internal/resource/database/model/user_like.go
@@ -30,7 +30,7 @@ const (
 type UserLike struct {
 	gorm.Model
 	UserID     uint           `json:"user_id" gorm:"not null;index:user_id_object_type;uniqueIndex:user_object;comment:用户ID"`
-	User       *User          `json:"user" gorm:"foreignKey:UserID;references:ID"`
+	User       *User          `json:"user" gorm:"foreignKey:UserID"`
 	ObjectID   uint           `json:"object_id" gorm:"not null;index:user_id_object_type;uniqueIndex:user_object;comment:对象ID"`
 	ObjectType LikeObjectType `json:"object_type" gorm:"not null;index:user_id_object_type;uniqueIndex:user_object;comment:对象类型"`
 }

--- a/internal/resource/database/model/user_view.go
+++ b/internal/resource/database/model/user_view.go
@@ -13,9 +13,9 @@ import (
 type UserView struct {
 	gorm.Model
 	UserID       uint      `json:"user_id" gorm:"not null;index:user_id_object_type;uniqueIndex:user_object;comment:用户ID"`
-	User         *User     `json:"user" gorm:"foreignKey:UserID;references:ID"`
+	User         *User     `json:"user" gorm:"foreignKey:UserID"`
 	ArticleID    uint      `json:"article_id" gorm:"not null;index:user_id_object_type;uniqueIndex:user_object;comment:文章ID"`
-	Article      *Article  `json:"article" gorm:"foreignKey:ArticleID;references:ID"`
+	Article      *Article  `json:"article" gorm:"foreignKey:ArticleID"`
 	LastViewedAt time.Time `json:"last_viewed_at" gorm:"not null;comment:最后浏览时间"`
 	Progress     int8      `json:"progress" gorm:"not null;comment:浏览进度"`
 }

--- a/internal/resource/database/postgresql.go
+++ b/internal/resource/database/postgresql.go
@@ -67,6 +67,8 @@ func InitDatabase() {
 	db = lo.Must(gorm.Open(dialector, &gorm.Config{
 		DryRun:         false, // 只生成SQL不运行
 		TranslateError: true,
+		// 逻辑外键：迁移时不创建物理外键
+		DisableForeignKeyConstraintWhenMigrating: true,
 		Logger: &GormLoggerAdapter{
 			LogLevel: gormlogger.Info, // Info级别
 		},
@@ -168,3 +170,4 @@ func (l *GormLoggerAdapter) Trace(ctx context.Context, begin time.Time, fc func(
 
 	logger.LoggerWithContext(ctx).Info("[GORM] trace", fields...)
 }
+


### PR DESCRIPTION
Refactor DAO layer to use logical foreign keys by disabling physical FK creation and removing explicit model references.

---
<a href="https://cursor.com/background-agent?bcId=bc-fdd0e6e6-a8fd-43c5-8b09-39a056646b20">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fdd0e6e6-a8fd-43c5-8b09-39a056646b20">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

